### PR TITLE
Fix for `vector comparision in partitionCells` issue #176

### DIFF
--- a/R/clustering.R
+++ b/R/clustering.R
@@ -270,7 +270,7 @@ clusterCells <- function(cds,
 louvain_clustering <- function(data, pd, k = 20, weight = F, louvain_iter = 1, resolution = NULL, random_seed = 0L, verbose = F, ...) {
   extra_arguments <- list(...)
   cell_names <- row.names(pd)
-  if(cell_names != row.names(pd))
+  if(!identical(cell_names, row.names(pd)))
     stop("phenotype and row name from the data doesn't match")
   
   if (is.data.frame(data))


### PR DESCRIPTION
I run into the exact same error when running `partitionCells` reported in issue #176 . Implemented the suggested fix. 